### PR TITLE
rebuild windows compilation fix for VS2015

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -69,7 +69,9 @@
 
 	#define strcasecmp _stricmp
 	#define strncasecmp _strnicmp
+#if defined(_MSC_VER) && _MSC_VER <1900
 	#define snprintf _snprintf
+#endif
 	//#define isfinite _finite
 	//#define isnan _isnan
 


### PR DESCRIPTION
snprintf is already defined in VS2015 (_MSC_VER == 1900). 
See reference http://stackoverflow.com/questions/27754492/vs-2015-compiling-cocos2d-x-3-3-error-fatal-error-c1189-error-macro-definiti
You also need updated hxcpp, windows 10, VS2015(RC) and had to use -DHXCPP_FORCE_PDB_SERVER