### PR TITLE
Compile fix for Visual Studio 2015

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -69,7 +69,9 @@
 
 	#define strcasecmp _stricmp
 	#define strncasecmp _strnicmp
-	#define snprintf _snprintf
+	#if _MSC_VER < 1900
+		#define snprintf _snprintf
+	#endif
 	//#define isfinite _finite
 	//#define isnan _isnan
 


### PR DESCRIPTION
This will fix the compile error on VS2015. Same error as this one:

c++ - VS 2015 compiling cocos2d-x 3.3 error "fatal error C1189: #error: Macro definition of snprintf conflicts with Standard Library function declaration" - Stack Overflow http://stackoverflow.com/questions/27754492/vs-2015-compiling-cocos2d-x-3-3-error-fatal-error-c1189-error-macro-definiti